### PR TITLE
Upgrade sbt from 1.3.9 to 1.3.10

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.10


### PR DESCRIPTION
In a fresh, clean repository, I did a scalaVersion to show 1.3.10
in use, then a publishLocal, and timerExample/run.

No problems seen.