### PR TITLE
build.sbt: Add ReloadOnSourceChanges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,9 @@ homepage := Some(url("https://github.com/scala-native/scala-native-loop"))
 licenses := Seq(
   "Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
 )
+
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
 publishMavenStyle := true
 Test / publishArtifact := false
 pomIncludeRepository := { _ => false }


### PR DESCRIPTION
This setting reduces the need to remember to manually reload sbt after
editing files which affect the build itself: build.sbt,
project/*.[sbt, scala], etc.