### PR TITLE
build.sbt: Rework scalacOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,9 +35,13 @@ lazy val commonSettings = Seq(
   version := "0.1.1-SNAPSHOT",
   scalaVersion := "2.11.12",
   scalacOptions ++= Seq(
+    "-deprecation",
+    "-encoding",
+    "utf8",
     "-feature",
-    "-Ywarn-unused-import",
-    "-Xfatal-warnings"
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Ywarn-unused-import"
   ),
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
   publish / skip := true,


### PR DESCRIPTION
Add scalacOptions which have proved useful in the ScalaNative build
itself.  The options here are not exactly the same. For example,
this build uses, rightly, -Yno-unused-imports.

Tested manually. No fatal or warning messages were found whilst building
the current code base.  Enabling these options should help keep deprecation
warnings & such from unintentionally creeping in as the code base
evolves.

No documentation impact.