### PR TITLE
build: Add dirty-money plugin for cleaning .ivy2 caches

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0-M2")
+addSbtPlugin("com.eed3si9n"     % "sbt-dirty-money"  % "0.2.0")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"          % "2.0.0")
 addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"     % "3.8.1")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"     % "2.3.4")


### PR DESCRIPTION
The dirty-money plugin has been used by the Scala Native project build
for two years or so.  It has proven itself useful to those of us
who do publishLocal a lot. It saves time & errors.

The plugin allows one to selectively clean .ivy2 caches, both global
and, especially, local of artifacts.  This helps ensure that misleading
stale artifacts are not left lying around.

No documentation impact.  Someday there will/may be a brief Contributors.md
guide.

Tested manually:

 1) Safety

 Using this PR, the following sequence completed successfully:
          `clean ; cleanCache; cleanLocal; publishLocal`

 The prior practice of manually removing the .ivy2/local/dev.whaling directory tree and 
then doing a `publishLocal` also executed as previously.

2) Efficacy

Using this PR, the global & local caches, as selected, are
emptied.  This can be shown by a sequence of:
```
manually remove the .ivy2/local/dev.whaling directory tree
show cleanLocalFiles # should be empty
 publishLocal
show cleanLocalFiles # should show files
cleanLocal
show cleanLocalFiles # should now be empty files
```
A corresponding sequence works for showing and cleaning the global cache.
