### PR TITLE
Quiet core/test "close multiple times" test

### DIFF
--- a/core/src/test/scala/scala/scalanative/loop/TimerTests.scala
+++ b/core/src/test/scala/scala/scalanative/loop/TimerTests.scala
@@ -60,6 +60,7 @@ object TimerTests extends LoopTestSuite {
         timer.clear()
         timer.clear()
       }
+      ()
     }
   }
 }

--- a/core/src/test/scala/scala/scalanative/loop/TimerTests.scala
+++ b/core/src/test/scala/scala/scalanative/loop/TimerTests.scala
@@ -52,6 +52,7 @@ object TimerTests extends LoopTestSuite {
       } yield ()
     }
     test("close multiple times") {
+      val p = Promise[Unit]()
       val timer = Timer.timeout(10.millis)(() => {})
       timer.clear()
       timer.clear()
@@ -59,8 +60,9 @@ object TimerTests extends LoopTestSuite {
       Timer.timeout(50.millis) { () =>
         timer.clear()
         timer.clear()
+        p.success(())
       }
-      ()
+      p.future
     }
   }
 }


### PR DESCRIPTION
As folks may know better than I, in uTest individual tests are documented
are documented as returning a value, which can itself be validated.
If the return value is not Unit, it is printed out.

Before this PR, the "close multiple times" test was returning the
value of an object, which was getting printed out and adding
something to the log which needed to be figured out as safe.

This PR causes that test to be silent, thereby reducing clutter.

Agreed, this is a nit. I think it is worth fixing because the present
file may serve as a cut & paste template for additional tests as they
are added.

If I can not fix something useful, I can at least remove a small wart.