### PR TITLE
use withClearIfTimeout in startTimer

### DIFF
--- a/core/src/main/scala/scala/scalanative/loop/Timer.scala
+++ b/core/src/main/scala/scala/scalanative/loop/Timer.scala
@@ -31,7 +31,6 @@ object Timer {
   ): Timer = {
     val timerHandle = stdlib.malloc(uv_handle_size(UV_TIMER_T))
     uv_timer_init(EventLoop.loop, timerHandle)
-    HandleUtils.setData(timerHandle, callback)
     val timer = new Timer(timerHandle)
     val withClearIfTimeout: () => Unit =
       if (repeat == 0L) { () =>
@@ -40,6 +39,7 @@ object Timer {
           timer.clear()
         }
       } else callback
+    HandleUtils.setData(timerHandle, withClearIfTimeout)
     uv_timer_start(timerHandle, timeoutCB, timeout, repeat)
     timer
   }


### PR DESCRIPTION
Hello! This PR is almost more of a curiosity, and I was wondering what your thoughts on it were - I noticed a `withClearIfTimeout` that wasn't used with `HandleUtils.setData` in `startTimer`, but it seems like it should be?

Also, the `"close multiple times"` test didn't work for me before any changes 😬 